### PR TITLE
Bump Runic format-check action to 1.10.0

### DIFF
--- a/.github/workflows/FormatCheck.yml
+++ b/.github/workflows/FormatCheck.yml
@@ -19,4 +19,4 @@ jobs:
       # - uses: julia-actions/cache@v2
       - uses: fredrikekre/runic-action@v1
         with:
-          version: '1.7.0'
+          version: '1.10.0'


### PR DESCRIPTION
Bumps the `fredrikekre/runic-action` version pin in `.github/workflows/FormatCheck.yml` from `1.7.0` to `1.10.0`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QDtqzZUdNquorEGoDbq1gC)_